### PR TITLE
Add partnerships email to partners  section

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1216,6 +1216,11 @@
 							</a>
 						</div>
 					</div>
+					<div class="sponsor-row-wrapper sponsor-community-row-wrapper-wide">
+						<div class="sponsor-logos-community">
+							<div class="talk_to_us summary"><p>Interested in partnering? Contact us at: <a class="front_contact_link" href="mailto:partnerships@qhacks.io">partnerships@qhacks.io</a></p></div>
+						</div>
+					</div>
 				</div>
 			</section>
 		</div>


### PR DESCRIPTION
**Requested by Jonah Gallant from Partnerships**
Added an email link to the bottom of the partners section for interested future partners
<img width="1095" alt="screen shot 2018-07-26 at 8 48 04 pm" src="https://user-images.githubusercontent.com/11237799/43295848-ac7f2172-9115-11e8-92d1-e2a2d9570c75.png">
