### PR TITLE
Add gatsby-plugin-netlify for domain redirecting

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -2,5 +2,9 @@ module.exports = {
   siteMetadata: {
     title: "QHacks Website"
   },
-  plugins: ["gatsby-plugin-react-helmet", "gatsby-plugin-glamor"]
+  plugins: [
+    "gatsby-plugin-react-helmet",
+    "gatsby-plugin-netlify",
+    "gatsby-plugin-glamor"
+  ]
 };

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,0 +1,7 @@
+exports.createPages = ({ actions }) => {
+
+  const { createRedirect } = actions;
+
+  createRedirect({ fromPath: "https://qhacks.ca/*", toPath: "https://qhacks.io/:splat", isPermanent: true, force: true });
+  createRedirect({ fromPath: "https://qhacks-website.netlify.com/*", toPath: "https://qhacks.io/:splat", isPermanent: true, force: true });
+};

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "gatsby": "next",
     "gatsby-plugin-glamor": "^2.0.5",
+    "gatsby-plugin-netlify": "^2.0.1",
     "gatsby-plugin-react-helmet": "next",
     "glamor": "^2.20.40",
     "react": "^16.5.0",


### PR DESCRIPTION
## Proposed Change

Related PR: https://github.com/gatsbyjs/gatsby/pull/8521

This adds a redirects file to our generated static site folder, i.e. `public/`. This will redirect our secondary domains to our primary domain.

### How did you do this?

Add the `gatsby-plugin-netlify` and configuration into `gatsby-node.js` file.

### Why are you choosing this approach?

Redirect our secondary domains to our primary domain.

### Any open questions you want to ask code reviewers?

Nope!

### List of changes:

  - Add `gatsby-plugin-netlify`.
  - Add config for `_redirects` file in `gatsby-config.js`.

## Pull Request Checklist:

  - [x] My submission passes all tests.
  - [x] I have lint my code locally prior to submission.
  - [x] I have written new tests for my core changes (where applicable).
  - [x] I have referenced all useful information (issues, tasks, etc) in the pull request.
