### PR TITLE
Set NODE_ENV to production on build command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1047,156 +1047,156 @@
       "integrity": "sha1-DTyzECL4Qn6ljACK8yuA2hJspOM="
     },
     "@webassemblyjs/ast": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.7.8.tgz",
-      "integrity": "sha512-dOrtdtEyB8sInpl75yLPNksY4sRl0j/+t6aHyB/YA+ab9hV3Fo7FmG12FHzP+2MvWVAJtDb+6eXR5EZbZJ+uVg==",
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.7.10.tgz",
+      "integrity": "sha512-wTUeaByYN2EA6qVqhbgavtGc7fLTOx0glG2IBsFlrFG51uXIGlYBTyIZMf4SPLo3v1bgV/7lBN3l7Z0R6Hswew==",
       "requires": {
-        "@webassemblyjs/helper-module-context": "1.7.8",
-        "@webassemblyjs/helper-wasm-bytecode": "1.7.8",
-        "@webassemblyjs/wast-parser": "1.7.8"
+        "@webassemblyjs/helper-module-context": "1.7.10",
+        "@webassemblyjs/helper-wasm-bytecode": "1.7.10",
+        "@webassemblyjs/wast-parser": "1.7.10"
       }
     },
     "@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.7.8.tgz",
-      "integrity": "sha512-kn2zNKGsbql5i56VAgRYkpG+VazqHhQQZQycT2uXAazrAEDs23gy+Odkh5VblybjnwX2/BITkDtNmSO76hdIvQ=="
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.7.10.tgz",
+      "integrity": "sha512-gMsGbI6I3p/P1xL2UxqhNh1ga2HCsx5VBB2i5VvJFAaqAjd2PBTRULc3BpTydabUQEGlaZCzEUQhLoLG7TvEYQ=="
     },
     "@webassemblyjs/helper-api-error": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.7.8.tgz",
-      "integrity": "sha512-xUwxDXsd1dUKArJEP5wWM5zxgCSwZApSOJyP1XO7M8rNUChUDblcLQ4FpzTpWG2YeylMwMl1MlP5Ztryiz1x4g=="
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.7.10.tgz",
+      "integrity": "sha512-DoYRlPWtuw3yd5BOr9XhtrmB6X1enYF0/54yNvQWGXZEPDF5PJVNI7zQ7gkcKfTESzp8bIBWailaFXEK/jjCsw=="
     },
     "@webassemblyjs/helper-buffer": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.7.8.tgz",
-      "integrity": "sha512-WXiIMnuvuwlhWvVOm8xEXU9DnHaa3AgAU0ZPfvY8vO1cSsmYb2WbGbHnMLgs43vXnA7XAob9b56zuZaMkxpCBg=="
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.7.10.tgz",
+      "integrity": "sha512-+RMU3dt/dPh4EpVX4u5jxsOlw22tp3zjqE0m3ftU2tsYxnPULb4cyHlgaNd2KoWuwasCQqn8Mhr+TTdbtj3LlA=="
     },
     "@webassemblyjs/helper-code-frame": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.7.8.tgz",
-      "integrity": "sha512-TLQxyD9qGOIdX5LPQOPo0Ernd88U5rHkFb8WAjeMIeA0sPjCHeVPaGqUGGIXjUcblUkjuDAc07bruCcNHUrHDA==",
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.7.10.tgz",
+      "integrity": "sha512-UiytbpKAULOEab2hUZK2ywXen4gWJVrgxtwY3Kn+eZaaSWaRM8z/7dAXRSoamhKFiBh1uaqxzE/XD9BLlug3gw==",
       "requires": {
-        "@webassemblyjs/wast-printer": "1.7.8"
+        "@webassemblyjs/wast-printer": "1.7.10"
       }
     },
     "@webassemblyjs/helper-fsm": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.7.8.tgz",
-      "integrity": "sha512-TjK0CnD8hAPkV5mbSp5aWl6SO1+H3WFcjWtixWoy8EMA99YnNzYhpc/WSYWhf7yrhpzkq5tZB0tvLK3Svr3IXA=="
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.7.10.tgz",
+      "integrity": "sha512-w2vDtUK9xeSRtt5+RnnlRCI7wHEvLjF0XdnxJpgx+LJOvklTZPqWkuy/NhwHSLP19sm9H8dWxKeReMR7sCkGZA=="
     },
     "@webassemblyjs/helper-module-context": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.7.8.tgz",
-      "integrity": "sha512-uCutAKR7Nm0VsFixcvnB4HhAyHouNbj0Dx1p7eRjFjXGGZ+N7ftTaG1ZbWCasAEbtwGj54LP8+lkBZdTCPmLGg=="
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.7.10.tgz",
+      "integrity": "sha512-yE5x/LzZ3XdPdREmJijxzfrf+BDRewvO0zl8kvORgSWmxpRrkqY39KZSq6TSgIWBxkK4SrzlS3BsMCv2s1FpsQ=="
     },
     "@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.7.8.tgz",
-      "integrity": "sha512-AdCCE3BMW6V34WYaKUmPgVHa88t2Z14P4/0LjLwuGkI0X6pf7nzp0CehzVVk51cKm2ymVXjl9dCG+gR1yhITIQ=="
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.7.10.tgz",
+      "integrity": "sha512-u5qy4SJ/OrxKxZqJ9N3qH4ZQgHaAzsopsYwLvoWJY6Q33r8PhT3VPyNMaJ7ZFoqzBnZlCcS/0f4Sp8WBxylXfg=="
     },
     "@webassemblyjs/helper-wasm-section": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.7.8.tgz",
-      "integrity": "sha512-BkBhYQuzyl4hgTGOKo87Vdw6f9nj8HhI7WYpI0MCC5qFa5ahrAPOGgyETVdnRbv+Rjukl9MxxfDmVcVC435lDg==",
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.7.10.tgz",
+      "integrity": "sha512-Ecvww6sCkcjatcyctUrn22neSJHLN/TTzolMGG/N7S9rpbsTZ8c6Bl98GpSpV77EvzNijiNRHBG0+JO99qKz6g==",
       "requires": {
-        "@webassemblyjs/ast": "1.7.8",
-        "@webassemblyjs/helper-buffer": "1.7.8",
-        "@webassemblyjs/helper-wasm-bytecode": "1.7.8",
-        "@webassemblyjs/wasm-gen": "1.7.8"
+        "@webassemblyjs/ast": "1.7.10",
+        "@webassemblyjs/helper-buffer": "1.7.10",
+        "@webassemblyjs/helper-wasm-bytecode": "1.7.10",
+        "@webassemblyjs/wasm-gen": "1.7.10"
       }
     },
     "@webassemblyjs/ieee754": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.7.8.tgz",
-      "integrity": "sha512-tOarWChdG1a3y1yqCX0JMDKzrat5tQe4pV6K/TX19BcXsBLYxFQOL1DEDa5KG9syeyvCrvZ+i1+Mv1ExngvktQ==",
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.7.10.tgz",
+      "integrity": "sha512-HRcWcY+YWt4+s/CvQn+vnSPfRaD4KkuzQFt5MNaELXXHSjelHlSEA8ZcqT69q0GTIuLWZ6JaoKar4yWHVpZHsQ==",
       "requires": {
         "@xtuc/ieee754": "^1.2.0"
       }
     },
     "@webassemblyjs/leb128": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.7.8.tgz",
-      "integrity": "sha512-GCYeGPgUFWJiZuP4NICbcyUQNxNLJIf476Ei+K+jVuuebtLpfvwkvYT6iTUE7oZYehhkor4Zz2g7SJ/iZaPudQ==",
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.7.10.tgz",
+      "integrity": "sha512-og8MciYlA8hvzCLR71hCuZKPbVBfLQeHv7ImKZ4nlyxrYbG7uJHYtHiHu6OV9SqrGuD03H/HtXC4Bgdjfm9FHw==",
       "requires": {
         "@xtuc/long": "4.2.1"
       }
     },
     "@webassemblyjs/utf8": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.7.8.tgz",
-      "integrity": "sha512-9X+f0VV+xNXW2ujfIRSXBJENGE6Qh7bNVKqu3yDjTFB3ar3nsThsGBBKdTG58aXOm2iUH6v28VIf88ymPXODHA=="
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.7.10.tgz",
+      "integrity": "sha512-Ng6Pxv6siyZp635xCSnH3mKmIFgqWPCcGdoo0GBYgyGdxu7cUj4agV7Uu1a8REP66UYUFXJLudeGgd4RvuJAnQ=="
     },
     "@webassemblyjs/wasm-edit": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.7.8.tgz",
-      "integrity": "sha512-6D3Hm2gFixrfyx9XjSON4ml1FZTugqpkIz5Awvrou8fnpyprVzcm4X8pyGRtA2Piixjl3DqmX/HB1xdWyE097A==",
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.7.10.tgz",
+      "integrity": "sha512-e9RZFQlb+ZuYcKRcW9yl+mqX/Ycj9+3/+ppDI8nEE/NCY6FoK8f3dKBcfubYV/HZn44b+ND4hjh+4BYBt+sDnA==",
       "requires": {
-        "@webassemblyjs/ast": "1.7.8",
-        "@webassemblyjs/helper-buffer": "1.7.8",
-        "@webassemblyjs/helper-wasm-bytecode": "1.7.8",
-        "@webassemblyjs/helper-wasm-section": "1.7.8",
-        "@webassemblyjs/wasm-gen": "1.7.8",
-        "@webassemblyjs/wasm-opt": "1.7.8",
-        "@webassemblyjs/wasm-parser": "1.7.8",
-        "@webassemblyjs/wast-printer": "1.7.8"
+        "@webassemblyjs/ast": "1.7.10",
+        "@webassemblyjs/helper-buffer": "1.7.10",
+        "@webassemblyjs/helper-wasm-bytecode": "1.7.10",
+        "@webassemblyjs/helper-wasm-section": "1.7.10",
+        "@webassemblyjs/wasm-gen": "1.7.10",
+        "@webassemblyjs/wasm-opt": "1.7.10",
+        "@webassemblyjs/wasm-parser": "1.7.10",
+        "@webassemblyjs/wast-printer": "1.7.10"
       }
     },
     "@webassemblyjs/wasm-gen": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.7.8.tgz",
-      "integrity": "sha512-a7O/wE6eBeVKKUYgpMK7NOHmMADD85rSXLe3CqrWRDwWff5y3cSVbzpN6Qv3z6C4hdkpq9qyij1Ga1kemOZGvQ==",
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.7.10.tgz",
+      "integrity": "sha512-M0lb6cO2Y0PzDye/L39PqwV+jvO+2YxEG5ax+7dgq7EwXdAlpOMx1jxyXJTScQoeTpzOPIb+fLgX/IkLF8h2yw==",
       "requires": {
-        "@webassemblyjs/ast": "1.7.8",
-        "@webassemblyjs/helper-wasm-bytecode": "1.7.8",
-        "@webassemblyjs/ieee754": "1.7.8",
-        "@webassemblyjs/leb128": "1.7.8",
-        "@webassemblyjs/utf8": "1.7.8"
+        "@webassemblyjs/ast": "1.7.10",
+        "@webassemblyjs/helper-wasm-bytecode": "1.7.10",
+        "@webassemblyjs/ieee754": "1.7.10",
+        "@webassemblyjs/leb128": "1.7.10",
+        "@webassemblyjs/utf8": "1.7.10"
       }
     },
     "@webassemblyjs/wasm-opt": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.7.8.tgz",
-      "integrity": "sha512-3lbQ0PT81NHCdi1sR/7+SNpZadM4qYcTSr62nFFAA7e5lFwJr14M1Gi+A/Y3PgcDWOHYjsaNGPpPU0H03N6Blg==",
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.7.10.tgz",
+      "integrity": "sha512-R66IHGCdicgF5ZliN10yn5HaC7vwYAqrSVJGjtJJQp5+QNPBye6heWdVH/at40uh0uoaDN/UVUfXK0gvuUqtVg==",
       "requires": {
-        "@webassemblyjs/ast": "1.7.8",
-        "@webassemblyjs/helper-buffer": "1.7.8",
-        "@webassemblyjs/wasm-gen": "1.7.8",
-        "@webassemblyjs/wasm-parser": "1.7.8"
+        "@webassemblyjs/ast": "1.7.10",
+        "@webassemblyjs/helper-buffer": "1.7.10",
+        "@webassemblyjs/wasm-gen": "1.7.10",
+        "@webassemblyjs/wasm-parser": "1.7.10"
       }
     },
     "@webassemblyjs/wasm-parser": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.7.8.tgz",
-      "integrity": "sha512-rZ/zlhp9DHR/05zh1MbAjT2t624sjrPP/OkJCjXqzm7ynH+nIdNcn9Ixc+qzPMFXhIrk0rBoQ3to6sEIvHh9jQ==",
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.7.10.tgz",
+      "integrity": "sha512-AEv8mkXVK63n/iDR3T693EzoGPnNAwKwT3iHmKJNBrrALAhhEjuPzo/lTE4U7LquEwyvg5nneSNdTdgrBaGJcA==",
       "requires": {
-        "@webassemblyjs/ast": "1.7.8",
-        "@webassemblyjs/helper-api-error": "1.7.8",
-        "@webassemblyjs/helper-wasm-bytecode": "1.7.8",
-        "@webassemblyjs/ieee754": "1.7.8",
-        "@webassemblyjs/leb128": "1.7.8",
-        "@webassemblyjs/utf8": "1.7.8"
+        "@webassemblyjs/ast": "1.7.10",
+        "@webassemblyjs/helper-api-error": "1.7.10",
+        "@webassemblyjs/helper-wasm-bytecode": "1.7.10",
+        "@webassemblyjs/ieee754": "1.7.10",
+        "@webassemblyjs/leb128": "1.7.10",
+        "@webassemblyjs/utf8": "1.7.10"
       }
     },
     "@webassemblyjs/wast-parser": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.7.8.tgz",
-      "integrity": "sha512-Q/zrvtUvzWuSiJMcSp90fi6gp2nraiHXjTV2VgAluVdVapM4gy1MQn7akja2p6eSBDQpKJPJ6P4TxRkghRS5dg==",
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.7.10.tgz",
+      "integrity": "sha512-YTPEtOBljkCL0VjDp4sHe22dAYSm3ZwdJ9+2NTGdtC7ayNvuip1wAhaAS8Zt9Q6SW9E5Jf5PX7YE3XWlrzR9cw==",
       "requires": {
-        "@webassemblyjs/ast": "1.7.8",
-        "@webassemblyjs/floating-point-hex-parser": "1.7.8",
-        "@webassemblyjs/helper-api-error": "1.7.8",
-        "@webassemblyjs/helper-code-frame": "1.7.8",
-        "@webassemblyjs/helper-fsm": "1.7.8",
+        "@webassemblyjs/ast": "1.7.10",
+        "@webassemblyjs/floating-point-hex-parser": "1.7.10",
+        "@webassemblyjs/helper-api-error": "1.7.10",
+        "@webassemblyjs/helper-code-frame": "1.7.10",
+        "@webassemblyjs/helper-fsm": "1.7.10",
         "@xtuc/long": "4.2.1"
       }
     },
     "@webassemblyjs/wast-printer": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.7.8.tgz",
-      "integrity": "sha512-GllIthRtwTxRDAURRNXscu7Napzmdf1jt1gpiZiK/QN4fH0lSGs3OTmvdfsMNP7tqI4B3ZtfaaWRlNIQug6Xyg==",
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.7.10.tgz",
+      "integrity": "sha512-mJ3QKWtCchL1vhU/kZlJnLPuQZnlDOdZsyP0bbLWPGdYsQDnSBvyTLhzwBA3QAMlzEL9V4JHygEmK6/OTEyytA==",
       "requires": {
-        "@webassemblyjs/ast": "1.7.8",
-        "@webassemblyjs/wast-parser": "1.7.8",
+        "@webassemblyjs/ast": "1.7.10",
+        "@webassemblyjs/wast-parser": "1.7.10",
         "@xtuc/long": "4.2.1"
       }
     },
@@ -3639,9 +3639,9 @@
       }
     },
     "css-select-base-adapter": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.0.tgz",
-      "integrity": "sha1-AQKz0UYw34bD65+p9UVicBBs+ZA="
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
+      "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w=="
     },
     "css-selector-tokenizer": {
       "version": "0.7.0",
@@ -5341,7 +5341,7 @@
     },
     "espree": {
       "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "resolved": "http://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
       "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "requires": {
         "acorn": "^5.5.0",
@@ -7091,15 +7091,14 @@
       }
     },
     "gatsby-link": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-2.0.4.tgz",
-      "integrity": "sha512-yz5tRpEPfabYrauOL/lg76z+TbV8Et3nmGX4vxfdiVI1pSsEsFyWIJwlK2z6cKGuBBvReoVmGQSYtvcRibgcpw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-2.0.5.tgz",
+      "integrity": "sha512-BmUmyq+ra2B7KlmbkLcn2WBwBcfQ+FEQUyW9KBpTewKB+5CBzsjb0UzqGPFdbnSHeT2HcqDD0PlZ1PaBl+EWZw==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "@reach/router": "^1.1.1",
         "@types/reach__router": "^1.0.0",
-        "prop-types": "^15.6.1",
-        "ric": "^1.3.0"
+        "prop-types": "^15.6.1"
       }
     },
     "gatsby-plugin-glamor": {
@@ -11862,14 +11861,14 @@
       }
     },
     "postcss-calc": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.0.tgz",
-      "integrity": "sha512-o04XICBwDxXVYw1TXkzxs36WRgk9OECGiSUoyYMNoFWHLAQCKKeaqhrNBTUKdStMfwik3gSLLztHebTSV5kJOA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.1.tgz",
+      "integrity": "sha512-oXqx0m6tb4N3JGdmeMSc/i91KppbYsFZKdH0xMOqK8V1rJlzrKlTdokz8ozUXLVejydRN6u2IddxpcijRj2FqQ==",
       "requires": {
         "css-unit-converter": "^1.1.1",
-        "postcss": "^7.0.2",
-        "postcss-selector-parser": "^5.0.0-rc.3",
-        "postcss-value-parser": "^3.3.0"
+        "postcss": "^7.0.5",
+        "postcss-selector-parser": "^5.0.0-rc.4",
+        "postcss-value-parser": "^3.3.1"
       },
       "dependencies": {
         "postcss": {
@@ -12637,132 +12636,19 @@
       }
     },
     "postcss-selector-parser": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0-rc.3.tgz",
-      "integrity": "sha512-kBl1vc+zJgWCBmmxEXE2/15tmmYdD50lO5r6tLNXEx3K4LtszdLFaSNo8SNVuoI+BGODbWhavoG/n1DrYphBsw==",
+      "version": "5.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0-rc.4.tgz",
+      "integrity": "sha512-0XvfYuShrKlTk1ooUrVzMCFQRcypsdEIsGqh5IxC5rdtBi4/M/tDAJeSONwC2MTqEFsmPZYAV7Dd4X8rgAfV0A==",
       "requires": {
-        "babel-eslint": "^8.2.3",
-        "cssesc": "^1.0.1",
+        "cssesc": "^2.0.0",
         "indexes-of": "^1.0.1",
         "uniq": "^1.0.1"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.0.0-beta.44",
-          "resolved": "http://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
-          "integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
-          "requires": {
-            "@babel/highlight": "7.0.0-beta.44"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.0.0-beta.44",
-          "resolved": "http://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz",
-          "integrity": "sha512-5xVb7hlhjGcdkKpMXgicAVgx8syK5VJz193k0i/0sLP6DzE6lRrU1K3B/rFefgdo9LPGMAOOOAWW4jycj07ShQ==",
-          "requires": {
-            "@babel/types": "7.0.0-beta.44",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.2.0",
-            "source-map": "^0.5.0",
-            "trim-right": "^1.0.1"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.0.0-beta.44",
-          "resolved": "http://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
-          "integrity": "sha512-MHRG2qZMKMFaBavX0LWpfZ2e+hLloT++N7rfM3DYOMUOGCD8cVjqZpwiL8a0bOX3IYcQev1ruciT0gdFFRTxzg==",
-          "requires": {
-            "@babel/helper-get-function-arity": "7.0.0-beta.44",
-            "@babel/template": "7.0.0-beta.44",
-            "@babel/types": "7.0.0-beta.44"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.0.0-beta.44",
-          "resolved": "http://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
-          "integrity": "sha512-w0YjWVwrM2HwP6/H3sEgrSQdkCaxppqFeJtAnB23pRiJB5E/O9Yp7JAAeWBl+gGEgmBFinnTyOv2RN7rcSmMiw==",
-          "requires": {
-            "@babel/types": "7.0.0-beta.44"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.0.0-beta.44",
-          "resolved": "http://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
-          "integrity": "sha512-aQ7QowtkgKKzPGf0j6u77kBMdUFVBKNHw2p/3HX/POt5/oz8ec5cs0GwlgM8Hz7ui5EwJnzyfRmkNF1Nx1N7aA==",
-          "requires": {
-            "@babel/types": "7.0.0-beta.44"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.0.0-beta.44",
-          "resolved": "http://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
-          "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
-          "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^3.0.0"
-          }
-        },
-        "@babel/template": {
-          "version": "7.0.0-beta.44",
-          "resolved": "http://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
-          "integrity": "sha512-w750Sloq0UNifLx1rUqwfbnC6uSUk0mfwwgGRfdLiaUzfAOiH0tHJE6ILQIUi3KYkjiCDTskoIsnfqZvWLBDng==",
-          "requires": {
-            "@babel/code-frame": "7.0.0-beta.44",
-            "@babel/types": "7.0.0-beta.44",
-            "babylon": "7.0.0-beta.44",
-            "lodash": "^4.2.0"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.0.0-beta.44",
-          "resolved": "http://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
-          "integrity": "sha512-UHuDz8ukQkJCDASKHf+oDt3FVUzFd+QYfuBIsiNu/4+/ix6pP/C+uQZJ6K1oEfbCMv/IKWbgDEh7fcsnIE5AtA==",
-          "requires": {
-            "@babel/code-frame": "7.0.0-beta.44",
-            "@babel/generator": "7.0.0-beta.44",
-            "@babel/helper-function-name": "7.0.0-beta.44",
-            "@babel/helper-split-export-declaration": "7.0.0-beta.44",
-            "@babel/types": "7.0.0-beta.44",
-            "babylon": "7.0.0-beta.44",
-            "debug": "^3.1.0",
-            "globals": "^11.1.0",
-            "invariant": "^2.2.0",
-            "lodash": "^4.2.0"
-          }
-        },
-        "@babel/types": {
-          "version": "7.0.0-beta.44",
-          "resolved": "http://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
-          "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.2.0",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "babel-eslint": {
-          "version": "8.2.6",
-          "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.6.tgz",
-          "integrity": "sha512-aCdHjhzcILdP8c9lej7hvXKvQieyRt20SF102SIGyY4cUIiw6UaAtK4j2o3dXX74jEmy0TJ0CEhv4fTIM3SzcA==",
-          "requires": {
-            "@babel/code-frame": "7.0.0-beta.44",
-            "@babel/traverse": "7.0.0-beta.44",
-            "@babel/types": "7.0.0-beta.44",
-            "babylon": "7.0.0-beta.44",
-            "eslint-scope": "3.7.1",
-            "eslint-visitor-keys": "^1.0.0"
-          }
-        },
         "cssesc": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-1.0.1.tgz",
-          "integrity": "sha512-S2hzrpWvE6G/rW7i7IxJfWBYn27QWfOIncUW++8Rbo1VB5zsJDSVPcnI+Q8z7rhxT6/yZeLOCja4cZnghJrNGA=="
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+          "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
         }
       }
     },
@@ -13861,11 +13747,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
       "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM="
-    },
-    "ric": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ric/-/ric-1.3.0.tgz",
-      "integrity": "sha1-jpUEJgnOghNUioMWTQjpT66UkJ8="
     },
     "rimraf": {
       "version": "2.6.2",
@@ -15155,9 +15036,9 @@
       }
     },
     "terser": {
-      "version": "3.10.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-3.10.2.tgz",
-      "integrity": "sha512-+QrFoqBImmsQGB4c/HvaqgZynmbNvNBwoBxuu7fYXtq5EEtlLUzph+WimDj+xMkuqawXPMl2lgCIz81CdXvt+w==",
+      "version": "3.10.3",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-3.10.3.tgz",
+      "integrity": "sha512-uyL5hwDICjnv49JANhZvQYLikt/HADWNbUFsKQpZ/i+JSOkL2T4V7WUpW7S/5QGZceVq2x0HRVhEQQuW2ZpX6g==",
       "requires": {
         "commander": "~2.17.1",
         "source-map": "~0.6.1",
@@ -16286,14 +16167,14 @@
       "dev": true
     },
     "webpack": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.22.0.tgz",
-      "integrity": "sha512-2+3EYFqyhPl12buLQ42QPHEEh8BHn3P9ipRvGRHhdfKJ1u9svhZ3QjhIoEdL5SeIhL5gfOZVbBnartYEabkEsg==",
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.23.1.tgz",
+      "integrity": "sha512-iE5Cu4rGEDk7ONRjisTOjVHv3dDtcFfwitSxT7evtYj/rANJpt1OuC/Kozh1pBa99AUBr1L/LsaNB+D9Xz3CEg==",
       "requires": {
-        "@webassemblyjs/ast": "1.7.8",
-        "@webassemblyjs/helper-module-context": "1.7.8",
-        "@webassemblyjs/wasm-edit": "1.7.8",
-        "@webassemblyjs/wasm-parser": "1.7.8",
+        "@webassemblyjs/ast": "1.7.10",
+        "@webassemblyjs/helper-module-context": "1.7.10",
+        "@webassemblyjs/wasm-edit": "1.7.10",
+        "@webassemblyjs/wasm-parser": "1.7.10",
         "acorn": "^5.6.2",
         "acorn-dynamic-import": "^3.0.0",
         "ajv": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     }
   },
   "scripts": {
-    "build": "gatsby build",
+    "build": "NODE_ENV=production gatsby build",
     "develop": "gatsby develop",
     "style": "eslint --quiet src/**/*.js",
     "format": "prettier --write 'src/**/*.js'",


### PR DESCRIPTION
## Proposed Change

This sets the `NODE_ENV` to be equal to `production` when running the `build` command. The reason this is needed is because it will make Netlify not install any dependencies in the `devDependencies` part of the `package.json`. 

Netlify does not need to install Cypress because our CI takes care of it, Netlify should only handle deploys.

### How did you do this?

Set `NODE_ENV` in the `build` script.

### Why are you choosing this approach?

Improve Netlify build speed!

### Any open questions you want to ask code reviewers?

Nope!

### List of changes:

  - Set `NODE_ENV` in build script.

## Pull Request Checklist:

  - [x] My submission passes all tests.
  - [x] I have lint my code locally prior to submission.
  - [x] I have written new unit tests for my core changes (where applicable).
  - [x] I have written browser integration tests for my core changes (where application).
  - [x] I have referenced all useful information (issues, tasks, etc) in the pull request.
