### PR TITLE
Fix MobileMenu scrolling issue

### DIFF
--- a/src/__tests__/pages/Index/__snapshots__/index.test.js.snap
+++ b/src/__tests__/pages/Index/__snapshots__/index.test.js.snap
@@ -36,14 +36,16 @@ exports[`IndexPage renders correctly 1`] = `
     }
     title="QHacks | Queen's University | Winter 2019"
   />
-  <Landing />
-  <MailingListSignup />
-  <About />
-  <Speakers />
-  <EventSchedule />
-  <HackerTestimonials />
-  <FAQs />
-  <Podcast />
-  <Footer />
+  <body>
+    <Landing />
+    <MailingListSignup />
+    <About />
+    <Speakers />
+    <EventSchedule />
+    <HackerTestimonials />
+    <FAQs />
+    <Podcast />
+    <Footer />
+  </body>
 </div>
 `;

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -35,6 +35,9 @@ class Header extends Component {
 
   onMobileMenuClicked = () => {
     this.setState({ isMobileMenuVisible: !this.state.isMobileMenuVisible });
+    document.body.style.overflow = this.state.isMobileMenuVisible
+      ? ""
+      : "hidden";
   };
 
   render() {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -41,14 +41,16 @@ export default () => (
         }
       ]}
     />
-    <Landing />
-    <MailingListSignup />
-    <About />
-    <Speakers />
-    <EventSchedule />
-    <HackerTestimonials />
-    <FAQs />
-    <Podcast />
-    <Footer />
+    <body>
+      <Landing />
+      <MailingListSignup />
+      <About />
+      <Speakers />
+      <EventSchedule />
+      <HackerTestimonials />
+      <FAQs />
+      <Podcast />
+      <Footer />
+    </body>
   </div>
 );


### PR DESCRIPTION
Fixes: #154

## Proposed Change
Currently, when the `MobileMenu` is open and you scroll, the elements that are covered by the menu still scroll.

### How did you do this?
Added a `<body>` tag to our `index` page and locked it when the mobile menu is open

### Why are you choosing this approach?
Better UX!

### Any open questions you want to ask code reviewers?
No

### List of changes:

  - Add a `<body>` to the `index` page
  - Add logic to `MobileMenu` component to lock the body from scrolling when open
  - Update tests

## Pull Request Checklist:

  - [x] My submission passes all tests.
  - [x] I have lint my code locally prior to submission.
  - [x] I have written new unit tests for my core changes (where applicable).
  - [x] I have written browser integration tests for my core changes (where application).
  - [x] I have referenced all useful information (issues, tasks, etc) in the pull request.
