### PR TITLE
Fix Footer responsiveness

### DIFF
--- a/src/__tests__/components/Footer/__snapshots__/Footer.test.js.snap
+++ b/src/__tests__/components/Footer/__snapshots__/Footer.test.js.snap
@@ -114,7 +114,7 @@ exports[`Footer renders correctly 1`] = `
         <div
           css={
             Object {
-              "@media(max-width: 840px)": Object {
+              "@media(max-width: 950px)": Object {
                 "display": "none",
               },
             }
@@ -262,7 +262,7 @@ exports[`Footer renders correctly 1`] = `
         <h3
           css={
             Object {
-              "@media (max-width: 840px)": Object {
+              "@media(max-width: 950px)": Object {
                 "display": "none",
               },
             }

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -161,7 +161,7 @@ const Footer = () => (
               dataCy="footer-signup-button"
             />
           </div>
-          <div css={{ "@media(max-width: 840px)": { display: "none" } }}>
+          <div css={{ [smallerScreens]: { display: "none" } }}>
             <p
               data-cy="footer-address"
               css={{ ...finePrint, paddingBottom: "6px" }}
@@ -228,9 +228,7 @@ const Footer = () => (
             }
           }}
         >
-          <h3 css={{ "@media (max-width: 840px)": { display: "none" } }}>
-            Get in touch
-          </h3>
+          <h3 css={{ [smallerScreens]: { display: "none" } }}>Get in touch</h3>
           <div
             css={{
               paddingTop: "30px",


### PR DESCRIPTION
## Proposed Change
Turns out I broke the responsiveness of the `Footer` in #140, certain elements were switching to mobile earlier than others.

### How did you do this?
Fixed the media queries that were happening too early

### Why are you choosing this approach?
To get rid of regressions!

### Any open questions you want to ask code reviewers?
No

### List of changes:

  - Update media queries on `Footer` to be consistent
  - Update tests

## Pull Request Checklist:

  - [x] My submission passes all tests.
  - [x] I have lint my code locally prior to submission.
  - [x] I have written new unit tests for my core changes (where applicable).
  - [x] I have written browser integration tests for my core changes (where application).
  - [x] I have referenced all useful information (issues, tasks, etc) in the pull request.
