### PR TITLE
Fix image aspect ratio issue in SellingPoints

### DIFF
--- a/src/__tests__/components/SellingPoints/__snapshots__/SellingPoints.test.js.snap
+++ b/src/__tests__/components/SellingPoints/__snapshots__/SellingPoints.test.js.snap
@@ -70,19 +70,28 @@ exports[`SellingPoints renders correctly 1`] = `
         }
       />
     </div>
-    <img
+    <div
       css={
         Object {
           "flex": 1,
           "margin": "0 28px 32px 28px",
-          "maxHeight": "320px",
-          "maxWidth": "475px",
+          "maxWidth": "510px",
           "minWidth": "300px",
           "textAlign": "center",
         }
       }
-      src="test-file-stub"
-    />
+    >
+      <img
+        css={
+          Object {
+            "maxHeight": "320px",
+            "maxWidth": "475px",
+            "width": "100%",
+          }
+        }
+        src="test-file-stub"
+      />
+    </div>
   </div>
   <div
     css={
@@ -97,19 +106,28 @@ exports[`SellingPoints renders correctly 1`] = `
       }
     }
   >
-    <img
+    <div
       css={
         Object {
           "flex": 1,
           "margin": "0 28px 32px 28px",
-          "maxHeight": "320px",
-          "maxWidth": "475px",
+          "maxWidth": "510px",
           "minWidth": "300px",
           "textAlign": "center",
         }
       }
-      src="test-file-stub"
-    />
+    >
+      <img
+        css={
+          Object {
+            "maxHeight": "320px",
+            "maxWidth": "475px",
+            "width": "100%",
+          }
+        }
+        src="test-file-stub"
+      />
+    </div>
     <div
       css={
         Object {

--- a/src/__tests__/components/Sponsors/__snapshots__/Sponsors.test.js.snap
+++ b/src/__tests__/components/Sponsors/__snapshots__/Sponsors.test.js.snap
@@ -360,6 +360,7 @@ exports[`Sponsors renders correctly 1`] = `
         foregroundColor="#c81c2e"
         style={
           Object {
+            "margin": "0 auto",
             "paddingLeft": "40px",
             "paddingRight": "40px",
           }

--- a/src/components/SellingPoints.js
+++ b/src/components/SellingPoints.js
@@ -23,10 +23,7 @@ const flexChildStyle = {
   flex: 1,
   textAlign: "center",
   minWidth: "300px",
-  margin: "0 28px 32px 28px"
-};
-
-const detailsStyle = {
+  margin: "0 28px 32px 28px",
   maxWidth: "510px"
 };
 
@@ -39,7 +36,8 @@ const blurbStyle = {
 
 const imgStyle = {
   maxHeight: "320px",
-  maxWidth: "475px"
+  maxWidth: "475px",
+  width: "100%"
 };
 
 const SellingPoints = () => (
@@ -50,7 +48,7 @@ const SellingPoints = () => (
         flexWrap: "wrap"
       }}
     >
-      <div css={{ ...flexChildStyle, ...detailsStyle }}>
+      <div css={flexChildStyle}>
         <h1>Grow Your Network.</h1>
         <p css={blurbStyle}>
           QHacks was first held in 2016 with a mission to advocate and incubate
@@ -80,10 +78,9 @@ const SellingPoints = () => (
           ]}
         />
       </div>
-      <img
-        src={qhacksSellingPointOne}
-        css={{ ...flexChildStyle, ...imgStyle }}
-      />
+      <div css={flexChildStyle}>
+        <img src={qhacksSellingPointOne} css={imgStyle} />
+      </div>
     </div>
     <div
       css={{
@@ -92,11 +89,10 @@ const SellingPoints = () => (
         marginBottom: 0
       }}
     >
-      <img
-        src={qhacksSellingPointTwo}
-        css={{ ...flexChildStyle, ...imgStyle }}
-      />
-      <div css={{ ...flexChildStyle, ...detailsStyle }}>
+      <div css={flexChildStyle}>
+        <img src={qhacksSellingPointTwo} css={imgStyle} />
+      </div>
+      <div css={flexChildStyle}>
         <h1>Showcase to Experts.</h1>
         <p css={blurbStyle}>
           This year, we have a colourful array of mentors, speakers, sponsors

--- a/src/components/Sponsors.js
+++ b/src/components/Sponsors.js
@@ -207,7 +207,11 @@ const Sponsors = () => (
         <ActionButton
           backgroundColor="#f8f8f8"
           foregroundColor="#c81c2e"
-          style={{ paddingLeft: "40px", paddingRight: "40px" }}
+          style={{
+            paddingLeft: "40px",
+            paddingRight: "40px",
+            margin: "0 auto"
+          }}
           type="rounded"
         >
           Become a partner


### PR DESCRIPTION
## Proposed Change

Fixes an issue where the aspect ratio of the images in `SellingPoints` would become distorted on small screens

### How did you do this?

Put the images in a wrapper instead of them actually being the flex child.

### Why are you choosing this approach?

It just works.

### Any open questions you want to ask code reviewers?

Nope

### List of changes:

  - Put images in a wrapper

## Pull Request Checklist:

  - [x] My submission passes all tests.
  - [x] I have lint my code locally prior to submission.
  - [x] I have written new unit tests for my core changes (where applicable).
  - [x] I have written browser integration tests for my core changes (where application).
  - [x] I have referenced all useful information (issues, tasks, etc) in the pull request.
