### PR TITLE
Make SpeakerSlider component more responsive

### DIFF
--- a/src/__tests__/components/SpeakerSlider/__snapshots__/SpeakerSlider.test.js.snap
+++ b/src/__tests__/components/SpeakerSlider/__snapshots__/SpeakerSlider.test.js.snap
@@ -12,6 +12,7 @@ exports[`SpeakerSlider renders correctly 1`] = `
 >
   <SpeakerSliderDots
     currentIndex={0}
+    onClick={[Function]}
     speakers={
       Array [
         Object {
@@ -30,10 +31,10 @@ exports[`SpeakerSlider renders correctly 1`] = `
     }
   />
   <Slider
+    afterChange={[Function]}
     arrows={false}
     dots={false}
     infinite={false}
-    onSwipe={[Function]}
   >
     <SpeakerCard
       description="Matthew is a machine learning Ph.D. and thought leader pioneering the field of applied artificial intelligence (AI). Matt's groundbreaking research in computer vision has propelled the image recognition industry from theory to real-world application. Matthew is a machine learning Ph.D. and thought leader pioneering the field of applied artificial intelligence (AI). Matt's groundbreaking research in computer vision has propelled the image recognition industry from theory to real-world application. Matthew is a machine learning Ph.D. and thought leader pioneering the field of applied artificial intelligence (AI). Matt's groundbreaking research in computer vision has propelled the image recognition industry from theory to real-world application. Matthew is a machine learning Ph.D. and ya."

--- a/src/__tests__/components/SpeakerSliderDots/SpeakerSliderDots.test.js
+++ b/src/__tests__/components/SpeakerSliderDots/SpeakerSliderDots.test.js
@@ -22,7 +22,9 @@ const speakers = [
 describe("SpeakerSliderDots", () => {
   it("renders correctly", () => {
     expect(
-      shallow(<SpeakerSliderDots speakers={speakers} />)
+      shallow(
+        <SpeakerSliderDots speakers={speakers} onClick={(num) => () => {}} />
+      )
     ).toMatchSnapshot();
   });
 });

--- a/src/__tests__/components/SpeakerSliderDots/__snapshots__/SpeakerSliderDots.test.js.snap
+++ b/src/__tests__/components/SpeakerSliderDots/__snapshots__/SpeakerSliderDots.test.js.snap
@@ -9,7 +9,7 @@ exports[`SpeakerSliderDots renders correctly 1`] = `
         "height": "6px",
         "marginLeft": "auto",
         "marginRight": "auto",
-        "transition": "1s",
+        "transition": "0.5s",
         "width": "6px",
       },
       "display": "grid",
@@ -28,6 +28,7 @@ exports[`SpeakerSliderDots renders correctly 1`] = `
       }
     }
     key="0"
+    onClick={[Function]}
   />
   <div
     css={
@@ -36,6 +37,7 @@ exports[`SpeakerSliderDots renders correctly 1`] = `
       }
     }
     key="1"
+    onClick={[Function]}
   />
 </div>
 `;

--- a/src/components/SpeakerSlider.js
+++ b/src/components/SpeakerSlider.js
@@ -10,27 +10,23 @@ class SpeakerSlider extends Component {
     super(props);
   }
 
-  handleSwipe = (direction) => {
-    const increment = direction === "left" ? 1 : -1;
-    if (
-      this.state.currentIndex + increment >= 0 &&
-      this.state.currentIndex + increment < this.props.speakers.length
-    ) {
-      this.setState({ currentIndex: this.state.currentIndex + increment });
-    }
-  };
+  handleChange = (currentIndex) => this.setState({ currentIndex });
 
   componentWillMount() {
     this.setState({ currentIndex: 0 });
   }
+
+  onSpeakerSliderDotsClicked = (num) => () => {
+    this.slider.slickGoTo(num);
+  };
 
   render() {
     const settings = {
       dots: false,
       arrows: false,
       infinite: false,
-      onSwipe: (direction) => {
-        this.handleSwipe(direction);
+      afterChange: (direction) => {
+        this.handleChange(direction);
       }
     };
 
@@ -39,8 +35,9 @@ class SpeakerSlider extends Component {
         <SpeakerSliderDots
           speakers={this.props.speakers}
           currentIndex={this.state.currentIndex}
+          onClick={this.onSpeakerSliderDotsClicked}
         />
-        <Slider {...settings}>
+        <Slider {...settings} ref={(slider) => (this.slider = slider)}>
           {this.props.speakers.map((speaker) => (
             <SpeakerCard {...speaker} key={speaker.name} />
           ))}

--- a/src/components/SpeakerSliderDots.js
+++ b/src/components/SpeakerSliderDots.js
@@ -12,7 +12,7 @@ const SpeakerSliderDots = (props) => (
         .reduce((a, b) => a + b),
       paddingBottom: "16px",
       ">div": {
-        transition: "1s",
+        transition: "0.5s",
         borderRadius: "50%",
         marginLeft: "auto",
         marginRight: "auto",
@@ -23,6 +23,7 @@ const SpeakerSliderDots = (props) => (
   >
     {props.speakers.map((_, i) => (
       <div
+        onClick={props.onClick(i)}
         key={i}
         css={{
           backgroundColor: i === props.currentIndex ? "#00205b" : "#aeb7c8"


### PR DESCRIPTION
## Proposed Change
Make the `Speakers` section better on mobile by making the dots usable and more reliable

### How did you do this?
Read through the api docs of `react-slick` and saw that the `afterChange` method was much better for our use case than `onSwipe` since there were times when the dots would change despite the speaker not changing on the slider

### Why are you choosing this approach?
To improve mobile UX!

### Any open questions you want to ask code reviewers?
No

### List of changes:

  - Add `onClick` method for `SpeakerSliderDots`
  - Change `onSwipe` to `afterChange`
  - Update tests

## Pull Request Checklist:

  - [x] My submission passes all tests.
  - [x] I have lint my code locally prior to submission.
  - [x] I have written new unit tests for my core changes (where applicable).
  - [x] I have written browser integration tests for my core changes (where application).
  - [x] I have referenced all useful information (issues, tasks, etc) in the pull request.
