### PR TITLE
Fix mobile menu bug on safari

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -38,9 +38,6 @@ class Header extends Component {
   enableScrolling = () => true;
 
   onMobileMenuClicked = () => {
-    document.ontouchmove = this.state.isMobileMenuVisible
-      ? this.enableScrolling
-      : this.disableScrolling;
     this.setState({ isMobileMenuVisible: !this.state.isMobileMenuVisible });
     document.body.style.overflow = this.state.isMobileMenuVisible
       ? ""
@@ -48,6 +45,13 @@ class Header extends Component {
   };
 
   render() {
+    // Throws an error during build command
+    try {
+      document.ontouchmove = this.state.isMobileMenuVisible
+        ? this.disableScrolling
+        : this.enableScrolling;
+    } catch (e) {}
+
     return (
       <div>
         <div


### PR DESCRIPTION
## Proposed Change

Fixes: #169 

### How did you do this?
Moved the logic for locking the screen (on mobile safari) into `render` as opposed to the `onMobileMenuClicked`

### Why are you choosing this approach?
For whatever reason, the `onMobileMenuClicked` solution was not working the first time the menu was opened on mobile safari, but this solution works on ALL times!

### Any open questions you want to ask code reviewers?
No

### List of changes:

  - Move logic for locking the mobile menu scrolling on safari into `render`

## Pull Request Checklist:

  - [x] My submission passes all tests.
  - [x] I have lint my code locally prior to submission.
  - [x] I have written new unit tests for my core changes (where applicable).
  - [x] I have written browser integration tests for my core changes (where application).
  - [x] I have referenced all useful information (issues, tasks, etc) in the pull request.
