### PR TITLE
Make SellingPoints floating image work better with HackerTestimonials

### DIFF
--- a/src/__tests__/components/SellingPoints/__snapshots__/SellingPoints.test.js.snap
+++ b/src/__tests__/components/SellingPoints/__snapshots__/SellingPoints.test.js.snap
@@ -225,20 +225,20 @@ exports[`SellingPoints renders correctly 1`] = `
         css={
           Object {
             "@media(max-width: 1200px)": Object {
-              "bottom": "-140px",
+              "bottom": "-120px",
               "height": "220px",
-              "left": "-45px",
+              "left": "-40px",
               "width": "358px",
             },
-            "@media(max-width: 850px)": Object {
+            "@media(max-width: 820px)": Object {
               "display": "none",
             },
-            "bottom": "-220px",
-            "height": "361px",
-            "left": "-100px",
+            "bottom": "-140px",
+            "height": "246px",
+            "left": "-60px",
             "position": "absolute",
-            "width": "588px",
-            "zIndex": -1,
+            "width": "400px",
+            "zIndex": 3,
           }
         }
       >
@@ -256,9 +256,10 @@ exports[`SellingPoints renders correctly 1`] = `
             Object {
               "@media(max-width: 1200px)": Object {
                 "height": "220px",
-                "position": "relative",
                 "width": "358px",
               },
+              "height": "246px",
+              "width": "400px",
             }
           }
           src="test-file-stub"

--- a/src/components/SellingPoints.js
+++ b/src/components/SellingPoints.js
@@ -147,19 +147,19 @@ const SellingPoints = () => (
         </div>
         <picture
           css={{
-            width: "588px",
-            height: "361px",
+            width: "400px",
+            height: "246px",
             position: "absolute",
-            bottom: "-220px",
-            left: "-100px",
-            zIndex: -1,
+            bottom: "-140px",
+            left: "-60px",
+            zIndex: 3,
             "@media(max-width: 1200px)": {
               width: "358px",
               height: "220px",
-              bottom: "-140px",
-              left: "-45px"
+              bottom: "-120px",
+              left: "-40px"
             },
-            "@media(max-width: 850px)": {
+            "@media(max-width: 820px)": {
               display: "none"
             }
           }}
@@ -168,8 +168,9 @@ const SellingPoints = () => (
           <source srcset={cubes2png} type="image/png" />
           <img
             css={{
+              width: "400px",
+              height: "246px",
               "@media(max-width: 1200px)": {
-                position: "relative",
                 width: "358px",
                 height: "220px"
               }


### PR DESCRIPTION
## Proposed Change

Make SellingPoints floating image work better with HackerTestimonials

### How did you do this?

Resize it and hide it at a certain width

### Why are you choosing this approach?

To make the white-space around this image look good

### Any open questions you want to ask code reviewers?

No

### List of changes:

  - Make SellingPoints floating image work better with HackerTestimonials

## Pull Request Checklist:

  - [x] My submission passes all tests.
  - [x] I have lint my code locally prior to submission.
  - [x] I have written new unit tests for my core changes (where applicable).
  - [x] I have written browser integration tests for my core changes (where application).
  - [x] I have referenced all useful information (issues, tasks, etc) in the pull request.
