### PR TITLE
Fix broken links in the mobile menu

### DIFF
--- a/src/__tests__/components/MobileMenu/__snapshots__/MobileMenu.test.js.snap
+++ b/src/__tests__/components/MobileMenu/__snapshots__/MobileMenu.test.js.snap
@@ -161,6 +161,7 @@ exports[`MobileMenu renders correctly 1`] = `
           css={
             Object {
               "marginTop": "-100px",
+              "pointerEvents": "none",
             }
           }
         >

--- a/src/components/MobileMenu.js
+++ b/src/components/MobileMenu.js
@@ -93,7 +93,7 @@ const MobileMenu = (props) => (
               </a>
             </div>
           ))}
-          <div css={{ marginTop: "-100px" }}>
+          <div css={{ marginTop: "-100px", pointerEvents: "none" }}>
             <picture>
               <source srcset={cubeswebp} type="image/webp" />
               <source srcset={cubespng} type="image/png" />


### PR DESCRIPTION
## Proposed Change
Fix some links that broke while making last minute changes

Fixes: #204 

### How did you do this?
Added css to stop the newly positioned cubes from covering the mobile menu links

### Why are you choosing this approach?
To fix bugs 🐛 

### Any open questions you want to ask code reviewers?
No

### List of changes:

  - Change `cubes` image css in `MobileMenu`
  - Update tests

## Pull Request Checklist:

  - [x] My submission passes all tests.
  - [x] I have lint my code locally prior to submission.
  - [x] I have written new unit tests for my core changes (where applicable).
  - [x] I have written browser integration tests for my core changes (where application).
  - [x] I have referenced all useful information (issues, tasks, etc) in the pull request.
