### PR TITLE
Fix desktop menu scrolling issue

### DIFF
--- a/src/__tests__/components/Menu/__snapshots__/Menu.test.js.snap
+++ b/src/__tests__/components/Menu/__snapshots__/Menu.test.js.snap
@@ -95,7 +95,7 @@ exports[`Menu renders correctly 1`] = `
           "TEST",
         ]
       }
-      offset={0}
+      offset={-1}
       onUpdate={[Function]}
       style={Object {}}
     >

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -18,7 +18,11 @@ const Menu = (props) => {
         css={{
           transition: "0.5s",
           "@media(min-width:820px)": {
-            display: props.standaloneVersion ? "inline-block" : (props.imgCss ? "inline-block" : "none")
+            display: props.standaloneVersion
+              ? "inline-block"
+              : props.imgCss
+                ? "inline-block"
+                : "none"
           }
         }}
       >
@@ -39,7 +43,11 @@ const Menu = (props) => {
         css={{
           display: "none",
           "@media(min-width:820px)": {
-            display: props.standaloneVersion ? "none" : (props.imgCss ? "none" : "inline-block")
+            display: props.standaloneVersion
+              ? "none"
+              : props.imgCss
+                ? "none"
+                : "inline-block"
           },
           transition: "0.5s"
         }}
@@ -77,6 +85,7 @@ const Menu = (props) => {
               .map(() => "min-content ")
               .reduce((a, b) => a + b)
           }}
+          offset={-1}
           items={props.menuItems}
           currentClassName="is-current"
         >


### PR DESCRIPTION
## Proposed Change
Add an `offset` to our `ScrollSpy` to fix the upwards scrolling issue related to the mobile menu.

Fixes: #246 

### How did you do this?
Read the [react-scrollspy](https://github.com/makotot/react-scrollspy) docs to see if there was a fix for this tiny bug

### Why are you choosing this approach?
To attain perfection ✨ 

### Any open questions you want to ask code reviewers?
No

### List of changes:

  - Add `offset` to `ScrollSpy` component
  - Update snapshots

## Pull Request Checklist:

  - [x] My submission passes all tests.
  - [x] I have lint my code locally prior to submission.
  - [x] I have written new unit tests for my core changes (where applicable).
  - [x] I have written browser integration tests for my core changes (where application).
  - [x] I have referenced all useful information (issues, tasks, etc) in the pull request.
